### PR TITLE
[Feature] 유저 관련 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 ### yml file ###
 application-dev.yml
 application-prod.yml
+application-jwt.yml
+application-oauth.yml

--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,19 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    // --- QueryDSL ---
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // -----
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,15 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/project/backend/global/auth/aop/AssignCurrentUserInfo.java
+++ b/src/main/java/project/backend/global/auth/aop/AssignCurrentUserInfo.java
@@ -1,0 +1,11 @@
+package project.backend.global.auth.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value =  ElementType.METHOD)
+public @interface AssignCurrentUserInfo {
+}

--- a/src/main/java/project/backend/global/auth/aop/AssignCurrentUserInfoAspect.java
+++ b/src/main/java/project/backend/global/auth/aop/AssignCurrentUserInfoAspect.java
@@ -1,0 +1,65 @@
+package project.backend.global.auth.aop;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import project.backend.user.infra.security.oauth.KakaoUserDetails;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Aspect
+@Component
+public class AssignCurrentUserInfoAspect {
+
+    // @AssignCurrentUserInfo가 있는 메서드 실행 전에 현재 유저의 ID를 CurrentUserInfo 객체에 할당
+    @Before("@annotation(project.backend.global.auth.aop.AssignCurrentUserInfo)")
+    public void assignUserId(JoinPoint joinPoint) {
+        Arrays.stream(joinPoint.getArgs())
+                .forEach(arg -> getMethod(arg.getClass())
+                        .ifPresent(
+                                setUserId -> invokeMethod(arg, setUserId, getCurrentUserId())));
+    }
+
+    // arg 객체의 setUserId 메서드를 호출하여 현재 유저의 ID를 할당
+    private void invokeMethod(Object arg, Method method, Long currentUserId) {
+        try {
+            method.invoke(arg, currentUserId);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // arg 객체의 setUserId 메서드를 찾아 반환
+    private Optional<Method> getMethod(Class<?> clazz) {
+        try {
+            return Optional.of(clazz.getMethod("setUserId", Long.class));
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
+    // 현재 유저의 ID를 반환
+    private Long getCurrentUserId() {
+        return getCurrentUserIdCheck()
+                .orElseThrow(RuntimeException::new);
+    }
+
+    private Optional<Long> getCurrentUserIdCheck() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof KakaoUserDetails) {
+            KakaoUserDetails kakaoUserDetails = (KakaoUserDetails) authentication.getPrincipal();
+            return Optional.ofNullable(kakaoUserDetails.getId());
+        }
+
+        // 인증된 정보가 null이거나 UserDetails가 아니라면 예외가 발생
+        throw new RuntimeException(); // todo. 예외 처리 수정
+    }
+
+}

--- a/src/main/java/project/backend/global/auth/aop/CurrentUserInfo.java
+++ b/src/main/java/project/backend/global/auth/aop/CurrentUserInfo.java
@@ -1,0 +1,16 @@
+package project.backend.global.auth.aop;
+
+
+import jakarta.validation.constraints.Null;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CurrentUserInfo {
+
+    @Null
+    private Long userId;
+
+}

--- a/src/main/java/project/backend/recruit/api/RecruitController.java
+++ b/src/main/java/project/backend/recruit/api/RecruitController.java
@@ -2,14 +2,18 @@ package project.backend.recruit.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import project.backend.global.auth.aop.AssignCurrentUserInfo;
+import project.backend.global.auth.aop.CurrentUserInfo;
 import project.backend.recruit.api.request.RecruitCreateRequest;
 import project.backend.recruit.application.RecruitService;
 
+@Slf4j
 @RestController
 @RequestMapping("/v1/recruits")
 @RequiredArgsConstructor
@@ -18,8 +22,11 @@ public class RecruitController {
     private final RecruitService recruitService;
 
     @PostMapping
-    public ResponseEntity<String> createRecruit(@RequestBody @Valid RecruitCreateRequest request) {
-        recruitService.createRecruit(request.toServiceRequest());
+    @AssignCurrentUserInfo
+    public ResponseEntity<String> createRecruit(
+            CurrentUserInfo userInfo,
+            @RequestBody @Valid RecruitCreateRequest request) {
+        recruitService.createRecruit(request.toServiceRequest(), userInfo.getUserId());
         return ResponseEntity.ok("모집글 등록 성공");
     }
 

--- a/src/main/java/project/backend/recruit/api/request/RecruitCreateRequest.java
+++ b/src/main/java/project/backend/recruit/api/request/RecruitCreateRequest.java
@@ -40,9 +40,6 @@ public class RecruitCreateRequest {
     @NotBlank(message = "공지사항은 필수입니다.")
     private String notice;
 
-    @NotNull(message = "작성자는 필수입니다.")
-    private Long userId;
-
     @Builder
     public RecruitCreateRequest(
             String title,
@@ -53,8 +50,7 @@ public class RecruitCreateRequest {
             LocalDate startDate,
             LocalDate endDate,
             String level,
-            String notice,
-            Long userId) {
+            String notice) {
         this.title = title;
         this.content = content;
         this.image = image;
@@ -64,7 +60,6 @@ public class RecruitCreateRequest {
         this.endDate = endDate;
         this.level = level;
         this.notice = notice;
-        this.userId = userId;
     }
 
     public RecruitCreateServiceRequest toServiceRequest() {
@@ -78,7 +73,6 @@ public class RecruitCreateRequest {
                 .endDate(endDate)
                 .level(level)
                 .notice(notice)
-                .userId(userId)
                 .build();
     }
 

--- a/src/main/java/project/backend/recruit/application/RecruitService.java
+++ b/src/main/java/project/backend/recruit/application/RecruitService.java
@@ -17,8 +17,8 @@ public class RecruitService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void createRecruit(RecruitCreateServiceRequest request) {
-        User user = userRepository.findById(request.getUserId())
+    public void createRecruit(RecruitCreateServiceRequest request, Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(RuntimeException::new);
 
         recruitRepository.save(request.toEntity(user));

--- a/src/main/java/project/backend/recruit/application/request/RecruitCreateServiceRequest.java
+++ b/src/main/java/project/backend/recruit/application/request/RecruitCreateServiceRequest.java
@@ -22,7 +22,6 @@ public class RecruitCreateServiceRequest {
     private LocalDate endDate;
     private String level;
     private String notice;
-    private Long userId;
 
     @Builder
     public RecruitCreateServiceRequest(
@@ -34,8 +33,7 @@ public class RecruitCreateServiceRequest {
             LocalDate startDate,
             LocalDate endDate,
             String level,
-            String notice,
-            Long userId) {
+            String notice) {
         this.title = title;
         this.content = content;
         this.image = image;
@@ -45,7 +43,6 @@ public class RecruitCreateServiceRequest {
         this.endDate = endDate;
         this.level = level;
         this.notice = notice;
-        this.userId = userId;
     }
 
     public Recruit toEntity(User user) {

--- a/src/main/java/project/backend/user/api/AuthController.java
+++ b/src/main/java/project/backend/user/api/AuthController.java
@@ -1,0 +1,31 @@
+package project.backend.user.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import project.backend.user.application.AuthService;
+import project.backend.user.infra.security.jwt.token.TokenResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login/kakao")
+    public ResponseEntity<TokenResponse> loginKakao(@RequestParam(name = "code") String code)
+            throws JsonProcessingException {
+        TokenResponse tokenResponse = authService.kakaoLogin(code);
+        return new ResponseEntity<>(tokenResponse, HttpStatus.OK);
+    }
+
+    @GetMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissueToken(HttpServletRequest request) {
+        return new ResponseEntity<>(authService.reissueAccessToken(request), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/project/backend/user/application/AuthService.java
+++ b/src/main/java/project/backend/user/application/AuthService.java
@@ -1,0 +1,177 @@
+package project.backend.user.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import project.backend.user.domain.User;
+import project.backend.user.infra.security.jwt.token.RefreshToken;
+import project.backend.user.repository.RefreshTokenRedisRepository;
+import project.backend.user.infra.security.jwt.token.TokenProvider;
+import project.backend.user.infra.security.jwt.token.TokenResponse;
+import project.backend.user.repository.UserRepository;
+
+import java.util.Collections;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private static final String REFRESH_HEADER = "RefreshToken";
+
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirect_uri;
+
+    @Transactional
+    public TokenResponse kakaoLogin(String code) throws JsonProcessingException {
+        String token = getToken(code);
+        String email = getKakaoUserInfo(token);
+        User user = saveIfNonExist(email);
+
+        TokenResponse tokenResponse = tokenProvider.createToken(
+                String.valueOf(user.getId()), user.getEmail(), "USER");
+
+        saveRefreshTokenOnRedis(user, tokenResponse);
+
+        return tokenResponse;
+    }
+
+    private void saveRefreshTokenOnRedis(User user, TokenResponse response) {
+        refreshTokenRedisRepository.save(RefreshToken.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .authorities(Collections.singleton(new SimpleGrantedAuthority("USER")))
+                .refreshToken(response.getRefreshToken())
+                .build());
+    }
+
+    private String getToken(final String code) throws JsonProcessingException {
+        // HTTP 헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 바디 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoClientId);
+        body.add("client_secret", kakaoClientSecret);
+        body.add("redirect_uri", redirect_uri);
+        body.add("code", code);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        return jsonNode.get("access_token").asText();
+    }
+
+    private String getKakaoUserInfo(String token) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(headers);
+
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.POST,
+                    kakaoTokenRequest,
+                    String.class
+            );
+            String responseBody = response.getBody();
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(responseBody);
+            return jsonNode.get("kakao_account").get("email").asText();
+        } catch (HttpClientErrorException e) {
+            throw new RuntimeException();
+        }
+    }
+
+    @Transactional
+    public User saveIfNonExist(String email) {
+        return userRepository.findByEmail(email)
+                .orElseGet(() ->
+                        userRepository.save(
+                                User.createUser(email, "낯선 " + email.split("@")[0])
+                        )
+                );
+    }
+
+    public TokenResponse reissueAccessToken(HttpServletRequest request) {
+        String refreshToken = getTokenFromHeader(request, REFRESH_HEADER);
+
+        if (!tokenProvider.validate(refreshToken) || !tokenProvider.validateExpire(refreshToken)) {
+            throw new RuntimeException();
+        }
+
+        RefreshToken findToken = refreshTokenRedisRepository.findByRefreshToken(refreshToken);
+
+        TokenResponse tokenResponse = tokenProvider.createToken(
+                String.valueOf(findToken.getId()),
+                findToken.getEmail(),
+                findToken.getAuthority());
+
+        refreshTokenRedisRepository.save(RefreshToken.builder()
+                .id(findToken.getId())
+                .email(findToken.getEmail())
+                .authorities(findToken.getAuthorities())
+                .refreshToken(tokenResponse.getRefreshToken())
+                .build());
+
+        SecurityContextHolder.getContext()
+                .setAuthentication(tokenProvider.getAuthentication(tokenResponse.getAccessToken()));
+
+        return tokenResponse;
+    }
+
+    private String getTokenFromHeader(HttpServletRequest request, String headerName) {
+        String token = request.getHeader(headerName);
+        if (StringUtils.hasText(token)) {
+            return token;
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/project/backend/user/config/RedisConfig.java
+++ b/src/main/java/project/backend/user/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package project.backend.user.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+}

--- a/src/main/java/project/backend/user/config/SecurityConfig.java
+++ b/src/main/java/project/backend/user/config/SecurityConfig.java
@@ -44,7 +44,6 @@ public class SecurityConfig {
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/v1/auth/**").permitAll()
                         .requestMatchers("v1/exception/**").permitAll()
-                        .requestMatchers("/login/oauth2/code/kakao").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/project/backend/user/config/SecurityConfig.java
+++ b/src/main/java/project/backend/user/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package project.backend.user.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import project.backend.user.infra.security.jwt.JwtAccessDeniedHandler;
+import project.backend.user.infra.security.jwt.JwtAuthenticationFailEntryPoint;
+import project.backend.user.infra.security.jwt.JwtFilter;
+import project.backend.user.infra.security.oauth.KakaoUserDetailsService;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFailEntryPoint jwtAuthenticationFailEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtFilter jwtFilter;
+    private final KakaoUserDetailsService kakaoUserDetailsService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .oauth2Login(oauth -> {
+                    oauth.userInfoEndpoint(config -> config.userService(kakaoUserDetailsService));
+                })
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/v1/auth/**").permitAll()
+                        .requestMatchers("v1/exception/**").permitAll()
+                        .requestMatchers("/login/oauth2/code/kakao").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(exceptionHandling -> {
+                    exceptionHandling.authenticationEntryPoint(jwtAuthenticationFailEntryPoint);
+                    exceptionHandling.accessDeniedHandler(jwtAccessDeniedHandler);
+                });
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/project/backend/user/config/WebConfig.java
+++ b/src/main/java/project/backend/user/config/WebConfig.java
@@ -1,0 +1,26 @@
+package project.backend.user.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods(
+                        HttpMethod.GET.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.PATCH.name(),
+                        HttpMethod.DELETE.name()
+                )
+                .allowCredentials(true)
+                .exposedHeaders("*");
+    }
+
+}

--- a/src/main/java/project/backend/user/domain/User.java
+++ b/src/main/java/project/backend/user/domain/User.java
@@ -52,4 +52,11 @@ public class User extends BaseEntity {
         this.profileImage = profileImage;
     }
 
+    public static User createUser(String email, String name) {
+        return User.builder()
+                .email(email)
+                .name(name)
+                .build();
+    }
+
 }

--- a/src/main/java/project/backend/user/infra/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/project/backend/user/infra/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,28 @@
+package project.backend.user.infra.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final String EXCEPTION_ACCESS_HANDLER = "/exception/access-denied";
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        if (!request.isSecure()) {
+            String redirectUrl =
+                    "https://" + request.getServerName() + EXCEPTION_ACCESS_HANDLER;
+            response.sendRedirect(redirectUrl);
+        } else {
+            response.sendRedirect(EXCEPTION_ACCESS_HANDLER);
+        }
+    }
+
+}

--- a/src/main/java/project/backend/user/infra/security/jwt/JwtAuthenticationFailEntryPoint.java
+++ b/src/main/java/project/backend/user/infra/security/jwt/JwtAuthenticationFailEntryPoint.java
@@ -1,0 +1,28 @@
+package project.backend.user.infra.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFailEntryPoint implements AuthenticationEntryPoint {
+
+    private static final String EXCEPTION_ENTRY_POINT = "/exception/entry-point";
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        if (!request.isSecure()) {
+            String redirectUrl =
+                    "https://" + request.getServerName() + EXCEPTION_ENTRY_POINT;
+            response.sendRedirect(redirectUrl);
+        } else {
+            response.sendRedirect(EXCEPTION_ENTRY_POINT);
+        }
+    }
+
+}

--- a/src/main/java/project/backend/user/infra/security/jwt/JwtFilter.java
+++ b/src/main/java/project/backend/user/infra/security/jwt/JwtFilter.java
@@ -1,0 +1,76 @@
+package project.backend.user.infra.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import project.backend.user.infra.security.jwt.token.TokenProvider;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private static final String ACCESS_HEADER = "AccessToken";
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        log.info("URI = {}", request.getRequestURI());
+        if (isRequestPassURI(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = getTokenFromHeader(request, ACCESS_HEADER);
+
+        if (!tokenProvider.validateExpire(accessToken) && tokenProvider.validate(accessToken)) {
+            String redirectUrl =
+                    "https://" + request.getServerName() + "/api/exception/access-token-expired";
+            response.sendRedirect(redirectUrl);
+            return;
+        }
+
+        if (tokenProvider.validateExpire(accessToken) && tokenProvider.validate(accessToken)) {
+            SecurityContextHolder.getContext().setAuthentication(tokenProvider.getAuthentication(accessToken));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private static boolean isRequestPassURI(HttpServletRequest request) {
+        if (request.getRequestURI().equals("/")) {
+            return true;
+        }
+
+        if (request.getRequestURI().startsWith("/v1/auth")) {
+            return true;
+        }
+
+        if (request.getRequestURI().startsWith("/v1/exception")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private String getTokenFromHeader(HttpServletRequest request, String headerName) {
+        String token = request.getHeader(headerName);
+        if (StringUtils.hasText(token)) {
+            return token;
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/project/backend/user/infra/security/jwt/token/RefreshToken.java
+++ b/src/main/java/project/backend/user/infra/security/jwt/token/RefreshToken.java
@@ -1,0 +1,31 @@
+package project.backend.user.infra.security.jwt.token;
+
+import lombok.*;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+
+@Builder
+@Getter
+@RedisHash(value = "refresh", timeToLive = 604800)
+public class RefreshToken {
+
+    private Long id;
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    @Indexed
+    private String refreshToken;
+
+    public String getAuthority() {
+        return authorities.stream()
+                .map(authority -> new SimpleGrantedAuthority(authority.getAuthority()))
+                .toList()
+                .getFirst()
+                .getAuthority();
+    }
+
+}

--- a/src/main/java/project/backend/user/infra/security/jwt/token/TokenProvider.java
+++ b/src/main/java/project/backend/user/infra/security/jwt/token/TokenProvider.java
@@ -1,0 +1,126 @@
+package project.backend.user.infra.security.jwt.token;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import project.backend.user.infra.security.oauth.KakaoUserDetails;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class TokenProvider {
+
+    private static final String AUTH_ID = "ID";
+    private static final String AUTH_KEY = "AUTHORITY";
+    private static final String AUTH_EMAIL = "EMAIL";
+    private Key key;
+    private String secretKey;
+    private long accessExpirations;
+    private long refreshExpirations;
+
+    public TokenProvider(@Value("${jwt.secret_key}") String secretKey,
+                         @Value("${jwt.access_expirations}") long accessExpirations,
+                         @Value("${jwt.refresh_expirations}") long refreshExpirations) {
+        this.secretKey = secretKey;
+        this.accessExpirations = accessExpirations * 1000;
+        this.refreshExpirations = refreshExpirations * 1000;
+    }
+
+    @PostConstruct
+    public void initKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = new SecretKeySpec(keyBytes, "HmacSHA256");
+    }
+
+    public TokenResponse createToken(String memberId, String email, String role) {
+        long now = (new Date()).getTime();
+
+        Date accessValidity = new Date(now + this.accessExpirations);
+        Date refreshValidity = new Date(now + this.refreshExpirations);
+
+        String accessToken = Jwts.builder()
+                .addClaims(Map.of(AUTH_ID, memberId))
+                .addClaims(Map.of(AUTH_EMAIL, email))
+                .addClaims(Map.of(AUTH_KEY, role))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setExpiration(accessValidity)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .addClaims(Map.of(AUTH_ID, memberId))
+                .addClaims(Map.of(AUTH_EMAIL, email))
+                .addClaims(Map.of(AUTH_KEY, role))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setExpiration(refreshValidity)
+                .compact();
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        List<String> authorities = Arrays.asList(claims.get(AUTH_KEY)
+                .toString()
+                .split(","));
+
+        List<? extends GrantedAuthority> simpleGrantedAuthorities = authorities.stream()
+                .map(auth -> new SimpleGrantedAuthority(auth))
+                .collect(Collectors.toList());
+
+        KakaoUserDetails principal = new KakaoUserDetails(Long.parseLong((String) claims.get(AUTH_ID)),
+                (String) claims.get(AUTH_EMAIL),
+                simpleGrantedAuthorities, Map.of());
+
+        return new UsernamePasswordAuthenticationToken(principal, token, simpleGrantedAuthorities);
+    }
+
+    public boolean validate(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            return false;
+        } catch (UnsupportedJwtException e) {
+            return false;
+        } catch (IllegalArgumentException e) {
+            return false;
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+    }
+
+    public boolean validateExpire(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/project/backend/user/infra/security/jwt/token/TokenResponse.java
+++ b/src/main/java/project/backend/user/infra/security/jwt/token/TokenResponse.java
@@ -1,0 +1,17 @@
+package project.backend.user.infra.security.jwt.token;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenResponse {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    public static TokenResponse of(final String accessToken, final String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+}

--- a/src/main/java/project/backend/user/infra/security/oauth/KakaoUserDetails.java
+++ b/src/main/java/project/backend/user/infra/security/oauth/KakaoUserDetails.java
@@ -1,0 +1,36 @@
+package project.backend.user.infra.security.oauth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public class KakaoUserDetails implements OAuth2User {
+
+    private final Long id;
+    private final String email;
+    private final List<? extends GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+
+    @Override
+    public String getName() {
+        return email;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+}

--- a/src/main/java/project/backend/user/infra/security/oauth/KakaoUserDetailsService.java
+++ b/src/main/java/project/backend/user/infra/security/oauth/KakaoUserDetailsService.java
@@ -1,0 +1,41 @@
+package project.backend.user.infra.security.oauth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import project.backend.user.domain.User;
+import project.backend.user.repository.UserRepository;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoUserDetailsService extends DefaultOAuth2UserService {
+
+    private static final String PREFIX = "낯선 ";
+    private static final String DEFAULT_ROLE = "USER";
+
+    private final UserRepository userRepository;
+
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+        String email = kakaoUserInfo.getEmail();
+
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> userRepository.save(
+                        User.createUser(email, PREFIX + email.split("@")[0])
+                ));
+
+        log.info("카카오 유저 = {}", user);
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(DEFAULT_ROLE);
+
+        return new KakaoUserDetails(user.getId(), email, List.of(authority), oAuth2User.getAttributes());
+    }
+
+}

--- a/src/main/java/project/backend/user/infra/security/oauth/KakaoUserInfo.java
+++ b/src/main/java/project/backend/user/infra/security/oauth/KakaoUserInfo.java
@@ -1,0 +1,30 @@
+package project.backend.user.infra.security.oauth;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+public class KakaoUserInfo {
+
+    public static final String KAKAO_ACCOUNT = "kakao_account";
+    public static final String EMAIL = "email";
+
+    private Map<String, Object> attributes;
+
+    public KakaoUserInfo(final Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getEmail() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        TypeReference<Map<String, Object>> typeReferencer = new TypeReference<>() {
+        };
+
+        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
+        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, typeReferencer);
+
+        return (String) account.get(EMAIL);
+    }
+
+}

--- a/src/main/java/project/backend/user/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/project/backend/user/repository/RefreshTokenRedisRepository.java
@@ -1,0 +1,10 @@
+package project.backend.user.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import project.backend.user.infra.security.jwt.token.RefreshToken;
+
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
+
+    RefreshToken findByRefreshToken(String refreshToken);
+
+}

--- a/src/main/java/project/backend/user/repository/UserRepository.java
+++ b/src/main/java/project/backend/user/repository/UserRepository.java
@@ -4,6 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import project.backend.user.domain.User;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,9 @@ spring:
         show_sql: true
         format_sql: true
     defer-datasource-initialization: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: password

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,6 @@ spring:
         - dev
       prod-env:
         - prod
+    include:
+      - jwt
+      - oauth

--- a/src/test/java/project/backend/recruit/api/RecruitControllerTest.java
+++ b/src/test/java/project/backend/recruit/api/RecruitControllerTest.java
@@ -1,16 +1,18 @@
 package project.backend.recruit.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import project.backend.recruit.api.request.RecruitCreateRequest;
-import project.backend.recruit.application.RecruitService;
+import project.backend.user.infra.security.jwt.token.TokenProvider;
+import project.backend.user.infra.security.jwt.token.TokenResponse;
 
 import java.time.LocalDate;
 
@@ -18,43 +20,50 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = RecruitController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 class RecruitControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @Autowired
     private ObjectMapper objectMapper;
 
     @Autowired
-    private MockMvc mockMvc;
+    private TokenProvider tokenProvider;
 
-    @Mock
-    private RecruitController recruitController;
+    @Value("${jwt.access_header}")
+    private String name;
+    private String validToken;
 
-    @MockBean
-    private RecruitService recruitService;
+    @BeforeEach
+    void setUp() {
+        TokenResponse tokenResponse = tokenProvider.createToken("1", "test@gmail.com", "USER");
+        validToken = "Bearer " + tokenResponse.getAccessToken();
+    }
 
     @DisplayName("모집글을 생성한다.")
     @Test
     void createRecruit() throws Exception {
-        //given
+        // given
         RecruitCreateRequest request = RecruitCreateRequest.builder()
                 .title("제목")
                 .content("내용")
                 .image("이미지")
-                .status("excepted")
+                .status("expected")
                 .region("서울")
                 .startDate(LocalDate.of(2024, 1, 1))
                 .endDate(LocalDate.of(2024, 1, 2))
                 .level("수준")
                 .notice("공지")
-                .userId(1L)
                 .build();
 
-        //when //then
-        mockMvc.perform(
-                        post("/v1/recruits")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON))
+        // when // then
+        mockMvc.perform(post("/v1/recruits")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(name, validToken))
                 .andExpect(status().isOk())
                 .andDo(print());
     }


### PR DESCRIPTION
## 💡 연관된 이슈
close #4 

## 📝 작업 내용
- 카카오 소셜 로그인을 구현했습니다.
- 로그인을 하면 AccessToken과 RefreshToken을 발급합니다.
- RefreshToken은 Redis에 저장해서 관리합니다.
- 메서드 호출 전에 유저 정보를 생성하는 AOP를 구현했습니다.
- QueryDSL 의존성도 추가했습니다.

## 💬 리뷰 요구 사항
- 궁금한 사항 있으면 남기십쇼. 😊 